### PR TITLE
Removed the use of schema for Sqlite as this is not supported by Sqlite and causes warnings during migrations

### DIFF
--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzBlobTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzBlobTriggerEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzBlobTriggerEntityTypeConfiguration : IEntityTypeConfiguration<QuartzBlobTrigger>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzBlobTriggerEntityTypeConfiguration(string prefix, string schema)
+  public QuartzBlobTriggerEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzBlobTrigger> builder)
   {
-    builder.ToTable(_prefix + "BLOB_TRIGGERS", _schema);
+    builder.ToTable(_prefix + "BLOB_TRIGGERS");
 
     builder.HasKey(x => new { x.SchedulerName, x.TriggerName, x.TriggerGroup });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzCalendarEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzCalendarEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzCalendarEntityTypeConfiguration : IEntityTypeConfiguration<QuartzCalendar>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzCalendarEntityTypeConfiguration(string prefix, string schema)
+  public QuartzCalendarEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzCalendar> builder)
   {
-    builder.ToTable(_prefix + "CALENDARS", _schema);
+    builder.ToTable(_prefix + "CALENDARS");
 
     builder.HasKey(x => new { x.SchedulerName, x.CalendarName });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzCronTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzCronTriggerEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzCronTriggerEntityTypeConfiguration : IEntityTypeConfiguration<QuartzCronTrigger>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzCronTriggerEntityTypeConfiguration(string prefix, string schema)
+  public QuartzCronTriggerEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzCronTrigger> builder)
   {
-    builder.ToTable(_prefix + "CRON_TRIGGERS", _schema);
+    builder.ToTable(_prefix + "CRON_TRIGGERS");
 
     builder.HasKey(x => new { x.SchedulerName, x.TriggerName, x.TriggerGroup });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzFiredTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzFiredTriggerEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzFiredTriggerEntityTypeConfiguration : IEntityTypeConfiguration<QuartzFiredTrigger>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzFiredTriggerEntityTypeConfiguration(string prefix, string schema)
+  public QuartzFiredTriggerEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzFiredTrigger> builder)
   {
-    builder.ToTable(_prefix + "FIRED_TRIGGERS", _schema);
+    builder.ToTable(_prefix + "FIRED_TRIGGERS");
 
     builder.HasKey(x => new { x.SchedulerName, x.EntryId });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzJobDetailEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzJobDetailEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzJobDetailEntityTypeConfiguration : IEntityTypeConfiguration<QuartzJobDetail>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzJobDetailEntityTypeConfiguration(string prefix, string schema)
+  public QuartzJobDetailEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzJobDetail> builder)
   {
-    builder.ToTable(_prefix + "JOB_DETAILS", _schema);
+    builder.ToTable(_prefix + "JOB_DETAILS");
 
     builder.HasKey(x => new { x.SchedulerName, x.JobName, x.JobGroup });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzLockEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzLockEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzLockEntityTypeConfiguration : IEntityTypeConfiguration<QuartzLock>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzLockEntityTypeConfiguration(string prefix, string schema)
+  public QuartzLockEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzLock> builder)
   {
-    builder.ToTable(_prefix + "LOCKS", _schema);
+    builder.ToTable(_prefix + "LOCKS");
 
     builder.HasKey(x => new { x.SchedulerName, x.LockName });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzPausedTriggerGroupEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzPausedTriggerGroupEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzPausedTriggerGroupEntityTypeConfiguration : IEntityTypeConfiguration<QuartzPausedTriggerGroup>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzPausedTriggerGroupEntityTypeConfiguration(string prefix, string schema)
+  public QuartzPausedTriggerGroupEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzPausedTriggerGroup> builder)
   {
-    builder.ToTable(_prefix + "PAUSED_TRIGGER_GRPS", _schema);
+    builder.ToTable(_prefix + "PAUSED_TRIGGER_GRPS");
 
     builder.HasKey(x => new { x.SchedulerName, x.TriggerGroup });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzSchedulerStateEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzSchedulerStateEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzSchedulerStateEntityTypeConfiguration : IEntityTypeConfiguration<QuartzSchedulerState>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzSchedulerStateEntityTypeConfiguration(string prefix, string schema)
+  public QuartzSchedulerStateEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzSchedulerState> builder)
   {
-    builder.ToTable(_prefix + "SCHEDULER_STATE", _schema);
+    builder.ToTable(_prefix + "SCHEDULER_STATE");
 
     builder.HasKey(x => new { x.SchedulerName, x.InstanceName });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzSimplePropertyTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzSimplePropertyTriggerEntityTypeConfiguration.cs
@@ -7,17 +7,15 @@ public class QuartzSimplePropertyTriggerEntityTypeConfiguration
   : IEntityTypeConfiguration<QuartzSimplePropertyTrigger>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzSimplePropertyTriggerEntityTypeConfiguration(string prefix, string schema)
+  public QuartzSimplePropertyTriggerEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzSimplePropertyTrigger> builder)
   {
-    builder.ToTable(_prefix + "SIMPROP_TRIGGERS", _schema);
+    builder.ToTable(_prefix + "SIMPROP_TRIGGERS");
 
     builder.HasKey(x => new { x.SchedulerName, x.TriggerName, x.TriggerGroup });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzSimpleTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzSimpleTriggerEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzSimpleTriggerEntityTypeConfiguration : IEntityTypeConfiguration<QuartzSimpleTrigger>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzSimpleTriggerEntityTypeConfiguration(string prefix, string schema)
+  public QuartzSimpleTriggerEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzSimpleTrigger> builder)
   {
-    builder.ToTable(_prefix + "SIMPLE_TRIGGERS", _schema);
+    builder.ToTable(_prefix + "SIMPLE_TRIGGERS");
 
     builder.HasKey(x => new { x.SchedulerName, x.TriggerName, x.TriggerGroup });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
@@ -6,17 +6,15 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 public class QuartzTriggerEntityTypeConfiguration : IEntityTypeConfiguration<QuartzTrigger>
 {
   private readonly string _prefix;
-  private readonly string _schema;
 
-  public QuartzTriggerEntityTypeConfiguration(string prefix, string schema)
+  public QuartzTriggerEntityTypeConfiguration(string prefix)
   {
     this._prefix = prefix;
-    this._schema = schema;
   }
 
   public void Configure(EntityTypeBuilder<QuartzTrigger> builder)
   {
-    builder.ToTable(_prefix + "TRIGGERS", _schema);
+    builder.ToTable(_prefix + "TRIGGERS");
 
     builder.HasKey(x => new { x.SchedulerName, x.TriggerName, x.TriggerGroup });
 

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/QuartzModelBuilderMysqlExtensions.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/QuartzModelBuilderMysqlExtensions.cs
@@ -2,42 +2,49 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite;
 
 public static class QuartzModelBuilderSQLiteExtensions
 {
-  public static QuartzModelBuilder UseSqlite(this QuartzModelBuilder builder, string prefix = "QRTZ_", string schema = "quartz")
+  /// <summary>
+  /// Setup the use of Sqlite tables for Quartz.NET.
+  /// <remarks>SQLite does not support schemas which is why no schema option can be set as this will be ignored by the SQLite provider.</remarks>
+  /// </summary>
+  /// <param name="builder">Fluent API to use Sqlite tables for Quartz.NET.</param>
+  /// <param name="prefix">Optional prefix for every table created.</param>
+  /// <returns></returns>
+  public static QuartzModelBuilder UseSqlite(this QuartzModelBuilder builder, string prefix = "QRTZ_")
   {
     builder.UseEntityTypeConfigurations(context =>
     {
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzJobDetailEntityTypeConfiguration(prefix, schema));
+        new QuartzJobDetailEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzTriggerEntityTypeConfiguration(prefix, schema));
+        new QuartzTriggerEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzSimpleTriggerEntityTypeConfiguration(prefix, schema));
+        new QuartzSimpleTriggerEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzSimplePropertyTriggerEntityTypeConfiguration(prefix, schema));
+        new QuartzSimplePropertyTriggerEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzCronTriggerEntityTypeConfiguration(prefix, schema));
+        new QuartzCronTriggerEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzBlobTriggerEntityTypeConfiguration(prefix, schema));
+        new QuartzBlobTriggerEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzCalendarEntityTypeConfiguration(prefix, schema));
+        new QuartzCalendarEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzPausedTriggerGroupEntityTypeConfiguration(prefix, schema));
+        new QuartzPausedTriggerGroupEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzFiredTriggerEntityTypeConfiguration(prefix, schema));
+        new QuartzFiredTriggerEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzSchedulerStateEntityTypeConfiguration(prefix, schema));
+        new QuartzSchedulerStateEntityTypeConfiguration(prefix));
 
       context.ModelBuilder.ApplyConfiguration(
-        new QuartzLockEntityTypeConfiguration(prefix, schema));
+        new QuartzLockEntityTypeConfiguration(prefix));
     });
 
     return builder;


### PR DESCRIPTION
Hi there again, 

I got a chance to migrate my project using a sqlite database which gave many warnings as shown here: 

```
Build started...
Build succeeded.
The Entity Framework tools version '6.0.4' is older than that of the runtime '6.0.6'. Update the tools for the latest features and bug fixes. See https://aka.ms/AAc1fbw for more information.
The entity type 'QuartzBlobTrigger' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzCalendar' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzCronTrigger' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzFiredTrigger' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzJobDetail' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzLock' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzPausedTriggerGroup' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzSchedulerState' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzSimplePropertyTrigger' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzSimpleTrigger' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
The entity type 'QuartzTrigger' is configured to use schema 'quartz', but SQLite does not support schemas. This configuration will be ignored by the SQLite provider.
```

Even though it says that the configuration is ignored, in my migration files the schema is still set:

```csharp
migrationBuilder.CreateTable(
    name: "QRTZ_CRON_TRIGGERS",
    schema: "quartz",
    columns: table => new
    {
        SCHED_NAME = table.Column<string>(type: "text", nullable: false),
        TRIGGER_NAME = table.Column<string>(type: "text", nullable: false),
        TRIGGER_GROUP = table.Column<string>(type: "text", nullable: false),
        CRON_EXPRESSION = table.Column<string>(type: "text", nullable: false),
        TIME_ZONE_ID = table.Column<string>(type: "text", nullable: true)
    },
    constraints: table =>
    {
        table.PrimaryKey("PK_QRTZ_CRON_TRIGGERS", x => new { x.SCHED_NAME, x.TRIGGER_NAME, x.TRIGGER_GROUP });
        table.ForeignKey(
            name: "FK_QRTZ_CRON_TRIGGERS_QRTZ_TRIGGERS_SCHED_NAME_TRIGGER_NAME_TRIGGER_GROUP",
            columns: x => new { x.SCHED_NAME, x.TRIGGER_NAME, x.TRIGGER_GROUP },
            principalSchema: "quartz",
            principalTable: "QRTZ_TRIGGERS",
            principalColumns: new[] { "SCHED_NAME", "TRIGGER_NAME", "TRIGGER_GROUP" },
            onDelete: ReferentialAction.Cascade);
    });

migrationBuilder.CreateTable(
    name: "QRTZ_SIMPLE_TRIGGERS",
    schema: "quartz",
    columns: table => new
    {
        SCHED_NAME = table.Column<string>(type: "text", nullable: false),
        TRIGGER_NAME = table.Column<string>(type: "text", nullable: false),
        TRIGGER_GROUP = table.Column<string>(type: "text", nullable: false),
        REPEAT_COUNT = table.Column<long>(type: "bigint", nullable: false),
        REPEAT_INTERVAL = table.Column<long>(type: "bigint", nullable: false),
        TIMES_TRIGGERED = table.Column<long>(type: "bigint", nullable: false)
    },
    constraints: table =>
    {
        table.PrimaryKey("PK_QRTZ_SIMPLE_TRIGGERS", x => new { x.SCHED_NAME, x.TRIGGER_NAME, x.TRIGGER_GROUP });
        table.ForeignKey(
            name: "FK_QRTZ_SIMPLE_TRIGGERS_QRTZ_TRIGGERS_SCHED_NAME_TRIGGER_NAME_TRIGGER_GROUP",
            columns: x => new { x.SCHED_NAME, x.TRIGGER_NAME, x.TRIGGER_GROUP },
            principalSchema: "quartz",
            principalTable: "QRTZ_TRIGGERS",
            principalColumns: new[] { "SCHED_NAME", "TRIGGER_NAME", "TRIGGER_GROUP" },
            onDelete: ReferentialAction.Cascade);
    });
```
I therefore removed all the schema options for the Sqlite package