### PR TITLE
Make entity classes partial to support extensibility

### DIFF
--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzBlobTrigger.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzBlobTrigger.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzBlobTrigger
+  public partial class QuartzBlobTrigger
   {
     public string SchedulerName { get; set; } = null!;
     public string TriggerName { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzCalendar.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzCalendar.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzCalendar
+  public partial class QuartzCalendar
   {
     public string SchedulerName { get; set; } = null!;
     public string CalendarName { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzCronTrigger.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzCronTrigger.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzCronTrigger
+  public partial class QuartzCronTrigger
   {
     public string SchedulerName { get; set; } = null!;
     public string TriggerName { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzFiredTrigger.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzFiredTrigger.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzFiredTrigger
+  public partial class QuartzFiredTrigger
   {
     public string SchedulerName { get; set; } = null!;
     public string EntryId { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzJobDetail.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzJobDetail.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzJobDetail
+  public partial class QuartzJobDetail
   {
     public string SchedulerName { get; set; } = null!;
     public string JobName { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzLock.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzLock.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzLock
+  public partial class QuartzLock
   {
     public string SchedulerName { get; set; } = null!;
     public string LockName { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzPausedTriggerGroup.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzPausedTriggerGroup.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzPausedTriggerGroup
+  public partial class QuartzPausedTriggerGroup
   {
     public string SchedulerName { get; set; } = null!;
     public string TriggerGroup { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzSchedulerState.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzSchedulerState.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzSchedulerState
+  public partial class QuartzSchedulerState
   {
     public string SchedulerName { get; set; } = null!;
     public string InstanceName { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzSimplePropertyTrigger.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzSimplePropertyTrigger.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzSimplePropertyTrigger
+  public partial class QuartzSimplePropertyTrigger
   {
     public string SchedulerName { get; set; } = null!;
     public string TriggerName { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzSimpleTrigger.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzSimpleTrigger.cs
@@ -1,6 +1,6 @@
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzSimpleTrigger
+  public partial class QuartzSimpleTrigger
   {
     public string SchedulerName { get; set; } = null!;
     public string TriggerName { get; set; } = null!;

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzTrigger.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzTrigger.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace AppAny.Quartz.EntityFrameworkCore.Migrations
 {
-  public class QuartzTrigger
+  public partial class QuartzTrigger
   {
     public string SchedulerName { get; set; } = null!;
     public string TriggerName { get; set; } = null!;


### PR DESCRIPTION
I'd like to extend the Quartz entity classes, and using partial classes would allow me to extend as desired.