### PR TITLE
feat(quartz): add misfire original fire time column mapping

### DIFF
--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
@@ -78,6 +78,10 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.MySql
         .HasColumnName("END_TIME")
         .HasColumnType("bigint(19)");
 
+      builder.Property(x => x.MisfireOriginalFireTime)
+        .HasColumnName("MISFIRE_ORIG_FIRE_TIME")
+        .HasColumnType("bigint(19)");
+
       builder.Property(x => x.CalendarName)
         .HasColumnName("CALENDAR_NAME")
         .HasColumnType("varchar(200)");

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
@@ -80,6 +80,10 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL
         .HasColumnName("end_time")
         .HasColumnType("bigint");
 
+      builder.Property(x => x.MisfireOriginalFireTime)
+        .HasColumnName("misfire_orig_fire_time")
+        .HasColumnType("bigint");
+
       builder.Property(x => x.CalendarName)
         .HasColumnName("calendar_name")
         .HasColumnType("text");

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
@@ -78,6 +78,10 @@ public class QuartzTriggerEntityTypeConfiguration : IEntityTypeConfiguration<Qua
       .HasColumnName("END_TIME")
       .HasColumnType("bigint");
 
+    builder.Property(x => x.MisfireOriginalFireTime)
+      .HasColumnName("MISFIRE_ORIG_FIRE_TIME")
+      .HasColumnType("bigint");
+
     builder.Property(x => x.CalendarName)
       .HasColumnName("CALENDAR_NAME")
       .HasColumnType("text");

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer/EntityTypeConfigurations/QuartzTriggerEntityTypeConfiguration.cs
@@ -84,6 +84,10 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer
         .HasColumnName("END_TIME")
         .HasColumnType("bigint");
 
+      builder.Property(x => x.MisfireOriginalFireTime)
+        .HasColumnName("MISFIRE_ORIG_FIRE_TIME")
+        .HasColumnType("bigint");
+
       builder.Property(x => x.CalendarName)
         .HasColumnName("CALENDAR_NAME")
         .HasMaxLength(200)

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzTrigger.cs
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/Quartz/QuartzTrigger.cs
@@ -17,6 +17,7 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations
     public string TriggerType { get; set; } = null!;
     public long StartTime { get; set; }
     public long? EndTime { get; set; }
+    public long? MisfireOriginalFireTime { get; set; }
     public string? CalendarName { get; set; } = null!;
     public short? MisfireInstruction { get; set; }
     public byte[]? JobData { get; set; }

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/QuartzTriggerModelMappingTests.cs
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/QuartzTriggerModelMappingTests.cs
@@ -1,0 +1,30 @@
+namespace AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests;
+
+using AppAny.Quartz.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+public class QuartzTriggerModelMappingTests
+{
+  [Fact]
+  public void ShouldMapMisfireOriginalFireTimeColumn()
+  {
+    var options = new DbContextOptionsBuilder<MySqlIntegrationDbContext>()
+      .UseMySql(
+        "Server=localhost;Port=3306;Database=quartz_mapping_tests;User=root;Password=password",
+        ServerVersion.Parse("8.0.36-mysql"))
+      .Options;
+
+    using var dbContext = new MySqlIntegrationDbContext(options);
+    var entityType = dbContext.Model.FindEntityType(typeof(QuartzTrigger));
+
+    Assert.NotNull(entityType);
+
+    var property = entityType!.FindProperty(nameof(QuartzTrigger.MisfireOriginalFireTime));
+    Assert.NotNull(property);
+
+    var table = StoreObjectIdentifier.Table(entityType.GetTableName()!, entityType.GetSchema());
+    Assert.Equal("MISFIRE_ORIG_FIRE_TIME", property!.GetColumnName(table));
+    Assert.Equal("bigint(19)", property.GetColumnType());
+  }
+}

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests/QuartzTriggerModelMappingTests.cs
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests/QuartzTriggerModelMappingTests.cs
@@ -1,0 +1,28 @@
+namespace AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests;
+
+using AppAny.Quartz.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+public class QuartzTriggerModelMappingTests
+{
+  [Fact]
+  public void ShouldMapMisfireOriginalFireTimeColumn()
+  {
+    var options = new DbContextOptionsBuilder<PostgreSqlIntegrationDbContext>()
+      .UseNpgsql("Host=localhost;Port=5432;Database=quartz_mapping_tests;Username=postgres;Password=postgres")
+      .Options;
+
+    using var dbContext = new PostgreSqlIntegrationDbContext(options);
+    var entityType = dbContext.Model.FindEntityType(typeof(QuartzTrigger));
+
+    Assert.NotNull(entityType);
+
+    var property = entityType!.FindProperty(nameof(QuartzTrigger.MisfireOriginalFireTime));
+    Assert.NotNull(property);
+
+    var table = StoreObjectIdentifier.Table(entityType.GetTableName()!, entityType.GetSchema());
+    Assert.Equal("misfire_orig_fire_time", property!.GetColumnName(table));
+    Assert.Equal("bigint", property.GetColumnType());
+  }
+}

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests/QuartzTriggerModelMappingTests.cs
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests/QuartzTriggerModelMappingTests.cs
@@ -1,0 +1,35 @@
+namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests;
+
+using AppAny.Quartz.EntityFrameworkCore.Migrations;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+public class QuartzTriggerModelMappingTests
+{
+  [Fact]
+  public void ShouldMapMisfireOriginalFireTimeColumn()
+  {
+    var connectionString = new SqliteConnectionStringBuilder
+    {
+      Mode = SqliteOpenMode.Memory,
+      DataSource = ":memory:"
+    }.ToString();
+
+    var options = new DbContextOptionsBuilder<SQLiteIntegrationDbContext>()
+      .UseSqlite(connectionString)
+      .Options;
+
+    using var dbContext = new SQLiteIntegrationDbContext(options);
+    var entityType = dbContext.Model.FindEntityType(typeof(QuartzTrigger));
+
+    Assert.NotNull(entityType);
+
+    var property = entityType!.FindProperty(nameof(QuartzTrigger.MisfireOriginalFireTime));
+    Assert.NotNull(property);
+
+    var table = StoreObjectIdentifier.Table(entityType.GetTableName()!, entityType.GetSchema());
+    Assert.Equal("MISFIRE_ORIG_FIRE_TIME", property!.GetColumnName(table));
+    Assert.Equal("bigint", property.GetColumnType());
+  }
+}

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests/QuartzTriggerModelMappingTests.cs
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests/QuartzTriggerModelMappingTests.cs
@@ -1,0 +1,28 @@
+namespace AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests;
+
+using AppAny.Quartz.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+public class QuartzTriggerModelMappingTests
+{
+  [Fact]
+  public void ShouldMapMisfireOriginalFireTimeColumn()
+  {
+    var options = new DbContextOptionsBuilder<SqlServerIntegrationDbContext>()
+      .UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=QuartzMappingTests;Trusted_Connection=True;")
+      .Options;
+
+    using var dbContext = new SqlServerIntegrationDbContext(options);
+    var entityType = dbContext.Model.FindEntityType(typeof(QuartzTrigger));
+
+    Assert.NotNull(entityType);
+
+    var property = entityType!.FindProperty(nameof(QuartzTrigger.MisfireOriginalFireTime));
+    Assert.NotNull(property);
+
+    var table = StoreObjectIdentifier.Table(entityType.GetTableName()!, entityType.GetSchema());
+    Assert.Equal("MISFIRE_ORIG_FIRE_TIME", property!.GetColumnName(table));
+    Assert.Equal("bigint", property.GetColumnType());
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds support for Quartz 3.17’s optional `MISFIRE_ORIG_FIRE_TIME` trigger column in the EF Core schema mappings used by this repo.

Related release note: https://github.com/quartznet/quartznet/releases/tag/v3.17.0

## Problem

Quartz introduced an optional `MISFIRE_ORIG_FIRE_TIME` column on `QRTZ_TRIGGERS` to preserve the original scheduled fire time for misfired triggers when using “fire now” policies.

Without this column in our EF model mappings:
- schema validation can fail against upgraded Quartz expectations
- `ScheduledFireTimeUtc` behavior for misfired triggers may not align with the new optional column support

## What this PR changes

- Added `MisfireOriginalFireTime` to the shared `QuartzTrigger` model.
- Mapped that property to provider-specific trigger columns:
  - SQL Server: `MISFIRE_ORIG_FIRE_TIME` (`bigint`)
  - PostgreSQL: `misfire_orig_fire_time` (`bigint`)
  - MySQL: `MISFIRE_ORIG_FIRE_TIME` (`bigint(19)`)
  - SQLite: `MISFIRE_ORIG_FIRE_TIME` (`bigint`)
- Added provider-level model mapping tests (SQL Server, PostgreSQL, MySQL, SQLite) to verify column name/type mapping.

## Scope / compatibility

- No breaking API changes.
- This is additive (nullable column mapping).
- Keeps behavior compatible while enabling Quartz 3.17 optional-column support across all provider projects in this solution.

## Validation

- Solution build passes across targets.
- Mapping tests were added for each provider to assert the new column metadata.