### PR TITLE
Add support for .NET10 and update nuget packages. 

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -21,8 +21,12 @@ jobs:
       - name: Package | Setup
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 10.0.x
-          dotnet-quality: 'preview'
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            9.0.x
+            8.0.x
+            10.0.x
 
       - name: Package | Publish
         run: dotnet pack -c Release -o ./pack /p:Version=$VERSION $PROJECT

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Package | Setup
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
           dotnet-quality: 'preview'
 
       - name: Package | Publish
@@ -41,7 +41,7 @@ jobs:
         env:
           PROJECT: src/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.csproj
           VERSION: ${{ steps.release.outputs.tag }}
-          
+
       - name: Package | Publish | SQLite
         run: dotnet pack -c Release -o ./pack /p:Version=$VERSION $PROJECT
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Tests | Setup
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
           dotnet-quality: 'preview'
 
       - name: Tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,8 +20,12 @@ jobs:
       - name: Tests | Setup
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 10.0.x
-          dotnet-quality: 'preview'
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            9.0.x
+            8.0.x
+            10.0.x
 
       - name: Tests
         run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.csproj
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -31,6 +31,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.csproj
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -31,6 +31,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.csproj
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
@@ -32,6 +32,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8"/>
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.csproj
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup Label="Assets">
@@ -49,10 +50,6 @@
       <Visible>false</Visible>
       <PackagePath />
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.csproj
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.csproj
@@ -23,32 +23,36 @@
   </PropertyGroup>
 
   <ItemGroup Label="Projects">
-    <ProjectReference Include="..\AppAny.Quartz.EntityFrameworkCore.Migrations\AppAny.Quartz.EntityFrameworkCore.Migrations.csproj"/>
+    <ProjectReference Include="..\AppAny.Quartz.EntityFrameworkCore.Migrations\AppAny.Quartz.EntityFrameworkCore.Migrations.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'" Label="Packages">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.20"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.20" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup Label="Assets">
     <None Include="../../assets/logo.png">
       <Pack>true</Pack>
       <Visible>false</Visible>
-      <PackagePath/>
+      <PackagePath />
     </None>
     <None Include="../../LICENSE">
       <Pack>true</Pack>
       <Visible>false</Visible>
-      <PackagePath/>
+      <PackagePath />
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.csproj
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -32,6 +32,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8"/>
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/src/AppAny.Quartz.EntityFrameworkCore.Migrations/AppAny.Quartz.EntityFrameworkCore.Migrations.csproj
+++ b/src/AppAny.Quartz.EntityFrameworkCore.Migrations/AppAny.Quartz.EntityFrameworkCore.Migrations.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -27,6 +27,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8"/>
   </ItemGroup>
 
   <ItemGroup Label="Assets">

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests.csproj
@@ -12,14 +12,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
     <PackageReference Include="Testcontainers.MySql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2"> 
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -30,14 +28,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="MySql.Data" Version="8.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="MySql.Data" Version="9.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MySql.Data" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
@@ -45,6 +37,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MySql.Data" Version="9.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
@@ -52,6 +46,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageReference Include="MySql.Data" Version="9.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
     <PackageReference Include="Testcontainers.MySql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests.csproj
@@ -1,25 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MySql.Data" Version="8.3.0" />
-    <PackageReference Include="Quartz" Version="3.8.1" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.8.1" />
-    <PackageReference Include="Testcontainers" Version="3.7.0" />
-    <PackageReference Include="Testcontainers.MySql" Version="3.7.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Quartz" Version="3.18.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
+    <PackageReference Include="Testcontainers" Version="4.12.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -31,9 +30,24 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="MySql.Data" Version="8.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="MySql.Data" Version="9.7.0" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/MySqlIntegrationDbContextIntegrationTests.cs
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/MySqlIntegrationDbContextIntegrationTests.cs
@@ -15,11 +15,19 @@ namespace AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests
     {
       this._connectionString = fixture.ConnectionString;
 
+#if NET10_0_OR_GREATER
+      // Oracle MySQL provider uses UseMySQL (capital SQL) and doesn't require ServerVersion parameter
+      var options = new DbContextOptionsBuilder<MySqlIntegrationDbContext>()
+        .UseMySQL(this._connectionString)
+        .Options;
+#else
+      // Pomelo provider uses UseMySql and requires ServerVersion parameter (NET8_0)
       var options = new DbContextOptionsBuilder<MySqlIntegrationDbContext>()
         .UseMySql(
           this._connectionString,
           ServerVersion.AutoDetect(fixture.ConnectionString))
         .Options;
+#endif
 
       this._dbContext = new MySqlIntegrationDbContext(options);
     }

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/QuartzTriggerModelMappingTests.cs
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.MySql.Tests/QuartzTriggerModelMappingTests.cs
@@ -9,11 +9,19 @@ public class QuartzTriggerModelMappingTests
   [Fact]
   public void ShouldMapMisfireOriginalFireTimeColumn()
   {
+#if NET10_0_OR_GREATER
+    // Oracle MySQL provider uses UseMySQL (capital SQL) and doesn't require ServerVersion parameter
+    var options = new DbContextOptionsBuilder<MySqlIntegrationDbContext>()
+      .UseMySQL("Server=localhost;Port=3306;Database=quartz_mapping_tests;User=root;Password=password")
+      .Options;
+#else
+    // Pomelo provider uses UseMySql and requires ServerVersion parameter (NET8_0)
     var options = new DbContextOptionsBuilder<MySqlIntegrationDbContext>()
       .UseMySql(
         "Server=localhost;Port=3306;Database=quartz_mapping_tests;User=root;Password=password",
         ServerVersion.Parse("8.0.36-mysql"))
       .Options;
+#endif
 
     using var dbContext = new MySqlIntegrationDbContext(options);
     var entityType = dbContext.Model.FindEntityType(typeof(QuartzTrigger));

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Quartz" Version="3.8.1" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.8.1" />
-    <PackageReference Include="Testcontainers" Version="3.7.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Quartz" Version="3.18.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
+    <PackageReference Include="Testcontainers" Version="4.12.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -33,6 +33,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL.Tests.csproj
@@ -12,7 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
@@ -29,6 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
@@ -36,6 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
@@ -43,6 +44,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests.csproj
@@ -12,7 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -27,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
@@ -34,6 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
@@ -41,6 +42,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite.Tests.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Quartz" Version="3.8.1" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.8.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Quartz" Version="3.18.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -31,6 +31,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Quartz" Version="3.8.1" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.8.1" />
-    <PackageReference Include="Testcontainers" Version="3.7.0" />
-    <PackageReference Include="Testcontainers.MsSql" Version="3.7.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Quartz" Version="3.18.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
+    <PackageReference Include="Testcontainers" Version="4.12.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -33,6 +33,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests.csproj
@@ -12,10 +12,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -30,6 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
@@ -37,6 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
@@ -44,6 +44,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
     <PackageReference Include="SharpCompress" Version="0.48.1" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
     <PackageReference Include="TestEnvironment.Docker.Containers.Postgres" Version="2.1.8" />
     <PackageReference Include="TestEnvironment.Docker.Containers.Mssql" Version="2.1.10" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="MySql.Data" Version="8.3.0" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.1" />
     <PackageReference Include="TestEnvironment.Docker.Containers.Postgres" Version="2.1.8" />
     <PackageReference Include="TestEnvironment.Docker.Containers.Mssql" Version="2.1.10" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests.csproj
@@ -8,12 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup Label="xUnit">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MySql.Data" Version="8.3.0" />
     <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
     <PackageReference Include="SharpCompress" Version="0.48.1" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
     <PackageReference Include="TestEnvironment.Docker.Containers.Postgres" Version="2.1.8" />
     <PackageReference Include="TestEnvironment.Docker.Containers.Mssql" Version="2.1.10" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -32,6 +29,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MySql.Data" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
@@ -39,6 +38,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MySql.Data" Version="9.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
@@ -46,6 +47,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MySql.Data" Version="9.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests.csproj
+++ b/tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests/AppAny.Quartz.EntityFrameworkCore.Migrations.Tests.csproj
@@ -1,25 +1,25 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup Label="xUnit">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MySql.Data" Version="8.3.0" />
-    <PackageReference Include="Quartz" Version="3.8.1" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.8.1" />
-    <PackageReference Include="TestEnvironment.Docker.Containers.Postgres" Version="2.1.6" />
-    <PackageReference Include="TestEnvironment.Docker.Containers.Mssql" Version="2.1.8" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Quartz" Version="3.18.1" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.18.1" />
+    <PackageReference Include="TestEnvironment.Docker.Containers.Postgres" Version="2.1.8" />
+    <PackageReference Include="TestEnvironment.Docker.Containers.Mssql" Version="2.1.10" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -34,6 +34,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'" Label="Packages">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'" Label="Packages">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Add support for .NET10 and update nuget packages. 

I'd also suggest to drop support for < .NET8.0 because everything lower is out of support. 
.NET8.0 will also run out of support in November 2026